### PR TITLE
Tcp support for streams

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,7 @@
 Release 0.4.0 (pending)
 ==========================
 
+- Added tcp support for streaming via remote:prot=tcp
 - Support for bulk register read/write interface APIs
 
 Release 0.3.1 (2016-09-01)

--- a/client/Settings.cpp
+++ b/client/Settings.cpp
@@ -19,7 +19,8 @@
  ******************************************************************/
 
 SoapyRemoteDevice::SoapyRemoteDevice(const std::string &url, const SoapySDR::Kwargs &args):
-    _logAcceptor(nullptr)
+    _logAcceptor(nullptr),
+    _defaultStreamProt("udp")
 {
     //try to connect to the remote server
     int ret = _sock.connect(url);
@@ -37,6 +38,10 @@ SoapyRemoteDevice::SoapyRemoteDevice(const std::string &url, const SoapySDR::Kwa
     packer & args;
     packer();
     SoapyRPCUnpacker unpacker(_sock);
+
+    //default stream protocol specified in device args
+    const auto protIt = args.find(SOAPY_REMOTE_KWARG_PROT);
+    if (protIt != args.end()) _defaultStreamProt = protIt->second;
 }
 
 SoapyRemoteDevice::~SoapyRemoteDevice(void)

--- a/client/Settings.cpp
+++ b/client/Settings.cpp
@@ -40,7 +40,7 @@ SoapyRemoteDevice::SoapyRemoteDevice(const std::string &url, const SoapySDR::Kwa
     SoapyRPCUnpacker unpacker(_sock);
 
     //default stream protocol specified in device args
-    const auto protIt = args.find(SOAPY_REMOTE_KWARG_PROT);
+    const auto protIt = args.find("prot");
     if (protIt != args.end()) _defaultStreamProt = protIt->second;
 }
 

--- a/client/SoapyClient.hpp
+++ b/client/SoapyClient.hpp
@@ -358,4 +358,5 @@ private:
     SoapyRPCSocket _sock;
     SoapyLogAcceptor *_logAcceptor;
     std::mutex _mutex;
+    std::string _defaultStreamProt;
 };

--- a/client/Streaming.cpp
+++ b/client/Streaming.cpp
@@ -276,6 +276,9 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
             delete data;
             throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
         }
+        SoapyRPCUnpacker unpacker(_sock);
+        unpacker & data->streamId;
+        unpacker & serverBindPort;
     }
 
     //create endpoint

--- a/client/Streaming.cpp
+++ b/client/Streaming.cpp
@@ -193,8 +193,9 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
     const auto remoteNode = SoapyURL(_sock.getpeername()).getNode();
 
     //bind the stream socket to an automatic port
-    const auto bindURL = SoapyURL("udp", localNode, "0").toString();
+    const auto bindURL = SoapyURL("tcp", localNode, "0").toString();
     int ret = data->streamSock.bind(bindURL);
+    data->streamSock.listen(1);
     if (ret != 0)
     {
         const std::string errorMsg = data->streamSock.lastErrorMsg();
@@ -206,6 +207,7 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
 
     //bind the status socket to an automatic port
     ret = data->statusSock.bind(bindURL);
+    data->statusSock.listen(1);
     if (ret != 0)
     {
         const std::string errorMsg = data->statusSock.lastErrorMsg();
@@ -227,12 +229,17 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
     packer & statusBindPort;
     packer();
 
+    //TODO this will leak the client socket, just for testing now....
+    data->streamSock = *data->streamSock.accept();
+    data->statusSock = *data->statusSock.accept();
+
     SoapyRPCUnpacker unpacker(_sock);
     std::string serverBindPort;
     unpacker & data->streamId;
     unpacker & serverBindPort;
 
     //connect the stream socket to the specified port
+    /*
     const auto connectURL = SoapyURL("udp", remoteNode, serverBindPort).toString();
     ret = data->streamSock.connect(connectURL);
     if (ret != 0)
@@ -242,6 +249,7 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
         throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
     }
     SoapySDR::logf(SOAPY_SDR_INFO, "Client side stream connected to %s", data->streamSock.getpeername().c_str());
+    */
 
     //create endpoint
     data->endpoint = new SoapyStreamEndpoint(data->streamSock, data->statusSock,

--- a/common/SoapyRemoteDefs.hpp
+++ b/common/SoapyRemoteDefs.hpp
@@ -23,6 +23,9 @@
 //! Stream args key to set the buffer MTU bytes for network transfers
 #define SOAPY_REMOTE_KWARG_MTU (SOAPY_REMOTE_KWARG_PREFIX "mtu")
 
+//! Stream args key to select the stream's protocol (tcp or udp)
+#define SOAPY_REMOTE_KWARG_PROT (SOAPY_REMOTE_KWARG_PREFIX "prot")
+
 /*!
  * Default stream transfer size (under network MTU).
  * Larger transfer sizes may not be supported in hardware

--- a/common/SoapyStreamEndpoint.cpp
+++ b/common/SoapyStreamEndpoint.cpp
@@ -208,7 +208,7 @@ int SoapyStreamEndpoint::acquireRecv(size_t &handle, const void **buffs, int &fl
 
     else while (bytesRecvd < bytes)
     {
-        ret = _streamSock.recv(data.buff.data()+ret, std::min<size_t>(SOAPY_REMOTE_SOCKET_BUFFMAX, bytes-ret));
+        ret = _streamSock.recv(data.buff.data()+bytesRecvd, std::min<size_t>(SOAPY_REMOTE_SOCKET_BUFFMAX, bytes-bytesRecvd));
         if (ret < 0)
         {
             SoapySDR::logf(SOAPY_SDR_ERROR, "StreamEndpoint::acquireRecv(), FAILED %s", _streamSock.lastErrorMsg());

--- a/common/SoapyStreamEndpoint.cpp
+++ b/common/SoapyStreamEndpoint.cpp
@@ -181,7 +181,7 @@ int SoapyStreamEndpoint::acquireRecv(size_t &handle, const void **buffs, int &fl
 
     //receive into the buffer
     assert(not _streamSock.null());
-    int ret = _streamSock.recv(data.buff.data(), data.buff.size());
+    int ret = _streamSock.recv(data.buff.data(), HEADER_SIZE);
     if (ret < 0)
     {
         SoapySDR::logf(SOAPY_SDR_ERROR, "StreamEndpoint::acquireRecv(), FAILED %s", _streamSock.lastErrorMsg());
@@ -192,6 +192,7 @@ int SoapyStreamEndpoint::acquireRecv(size_t &handle, const void **buffs, int &fl
     //check the header
     auto header = (const StreamDatagramHeader*)data.buff.data();
     size_t bytes = ntohl(header->bytes);
+    ret += _streamSock.recv(data.buff.data()+HEADER_SIZE, bytes-HEADER_SIZE); //get the rest knowing the size
     if (bytes > size_t(ret))
     {
         SoapySDR::logf(SOAPY_SDR_ERROR, "StreamEndpoint::acquireRecv(%d bytes), FAILED %d\n"

--- a/common/SoapyStreamEndpoint.hpp
+++ b/common/SoapyStreamEndpoint.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2015 Josh Blum
+// Copyright (c) 2015-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -19,6 +19,7 @@ public:
     SoapyStreamEndpoint(
         SoapyRPCSocket &streamSock,
         SoapyRPCSocket &statusSock,
+        const bool datagramMode,
         const bool isRecv,
         const size_t numChans,
         const size_t elemSize,
@@ -125,6 +126,7 @@ public:
 private:
     SoapyRPCSocket &_streamSock;
     SoapyRPCSocket &_statusSock;
+    const bool _datagramMode;
     const size_t _xferSize;
     const size_t _numChans;
     const size_t _elemSize;

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -328,7 +328,6 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         const auto remoteNode = SoapyURL(_sock.getpeername()).getNode();
 
         //bind the stream socket to an automatic port
-        /*
         const auto bindURL = SoapyURL("udp", localNode, "0").toString();
         int ret = data.streamSock.bind(bindURL);
         if (ret != 0)
@@ -339,11 +338,10 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         }
         SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", data.streamSock.getsockname().c_str());
         const auto serverBindPort = SoapyURL(data.streamSock.getsockname()).getService();
-        */
 
         //connect the stream socket to the specified port
-        auto connectURL = SoapyURL("tcp", remoteNode, clientBindPort).toString();
-        int ret = data.streamSock.connect(connectURL);
+        auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
+        ret = data.streamSock.connect(connectURL);
         if (ret != 0)
         {
             const std::string errorMsg = data.streamSock.lastErrorMsg();
@@ -353,7 +351,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock.getpeername().c_str());
 
         //connect the status socket to the specified port
-        connectURL = SoapyURL("tcp", remoteNode, statusBindPort).toString();
+        connectURL = SoapyURL("udp", remoteNode, statusBindPort).toString();
         ret = data.statusSock.connect(connectURL);
         if (ret != 0)
         {
@@ -365,7 +363,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
 
         //create endpoint
         data.endpoint = new SoapyStreamEndpoint(data.streamSock, data.statusSock,
-            direction == SOAPY_SDR_TX, channels.size(), SoapySDR::formatToSize(format), mtu, window);
+            direction == SOAPY_SDR_TX, true, channels.size(), SoapySDR::formatToSize(format), mtu, window);
 
         //start worker thread, this is not backwards,
         //receive from device means using a send endpoint
@@ -375,7 +373,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         data.startStatThread();
 
         packer & data.streamId;
-        packer & std::string("");//serverBindPort;
+        packer & serverBindPort;
     } break;
 
     ////////////////////////////////////////////////////////////////////

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -332,70 +332,81 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         const auto localNode = SoapyURL(_sock.getsockname()).getNode();
         const auto remoteNode = SoapyURL(_sock.getpeername()).getNode();
 
-        //bind the stream socket to an automatic port
         const auto bindURL = SoapyURL(prot, localNode, "0").toString();
-        SoapyRPCSocket tcpServerSocket;
-        auto &serverSocket = datagramMode?data.streamSock:tcpServerSocket;
-        int ret = serverSocket.bind(bindURL);
-        if (ret != 0)
-        {
-            const std::string errorMsg = serverSocket.lastErrorMsg();
-            _streamData.erase(data.streamId);
-            throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- bind FAIL: " + errorMsg);
-        }
-        SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", serverSocket.getsockname().c_str());
-        const auto serverBindPort = SoapyURL(serverSocket.getsockname()).getService();
+        std::string serverBindPort;
 
         //in udp mode connect to the bound sockets on the client side
         if (datagramMode)
         {
-            //connect the stream socket to the specified port
-            auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
-            ret = data.streamSock.connect(connectURL);
+            data.streamSock = new SoapyRPCSocket();
+            data.statusSock = new SoapyRPCSocket();
+
+            //bind the stream socket to an automatic port
+            int ret = data.streamSock->bind(bindURL);
             if (ret != 0)
             {
-                const std::string errorMsg = data.streamSock.lastErrorMsg();
+                const std::string errorMsg = data.streamSock->lastErrorMsg();
+                _streamData.erase(data.streamId);
+                throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- bind FAIL: " + errorMsg);
+            }
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", data.streamSock->getsockname().c_str());
+            serverBindPort = SoapyURL(data.streamSock->getsockname()).getService();
+
+            //connect the stream socket to the specified port
+            auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
+            ret = data.streamSock->connect(connectURL);
+            if (ret != 0)
+            {
+                const std::string errorMsg = data.streamSock->lastErrorMsg();
                 _streamData.erase(data.streamId);
                 throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
             }
-            SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock.getpeername().c_str());
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock->getpeername().c_str());
 
             //connect the status socket to the specified port
             connectURL = SoapyURL("udp", remoteNode, statusBindPort).toString();
-            ret = data.statusSock.connect(connectURL);
+            ret = data.statusSock->connect(connectURL);
             if (ret != 0)
             {
-                const std::string errorMsg = data.statusSock.lastErrorMsg();
+                const std::string errorMsg = data.statusSock->lastErrorMsg();
                 _streamData.erase(data.streamId);
                 throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
             }
-            SoapySDR::logf(SOAPY_SDR_INFO, "Server side status connected to %s", data.statusSock.getpeername().c_str());
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side status connected to %s", data.statusSock->getpeername().c_str());
         }
 
-        //in tcp mode, setup the server socket to listen
+        //in tcp mode, setup the server socket to listen,
+        //send the binding port back to the client and
+        //accept the client's new connections
         else
         {
+            SoapyRPCSocket serverSocket;
+            int ret = serverSocket.bind(bindURL);
+            if (ret != 0)
+            {
+                const std::string errorMsg = serverSocket.lastErrorMsg();
+                _streamData.erase(data.streamId);
+                throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- bind FAIL: " + errorMsg);
+            }
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", serverSocket.getsockname().c_str());
+            serverBindPort = SoapyURL(serverSocket.getsockname()).getService();
+
             serverSocket.listen(2);
-        }
-
-        packer & data.streamId;
-        packer & serverBindPort;
-
-        //tcp mode: flush the packer and accept the client's new connections
-        if (not datagramMode)
-        {
-            SoapyRPCPacker packer2(_sock);
-            packer2 & data.streamId;
-            packer2 & serverBindPort;
-            packer2();
-            //TODO fix leak
-            data.streamSock = *serverSocket.accept();
-            data.statusSock = *serverSocket.accept();
+            SoapyRPCPacker packerTcp(_sock);
+            packerTcp & serverBindPort;
+            packerTcp();
+            data.streamSock = serverSocket.accept();
+            data.statusSock = serverSocket.accept();
+            if (data.streamSock == nullptr or data.statusSock == nullptr)
+            {
+                const std::string errorMsg = serverSocket.lastErrorMsg();
+                throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- accept FAIL: " + errorMsg);
+            }
         }
 
         //create endpoint
-        data.endpoint = new SoapyStreamEndpoint(data.streamSock, data.statusSock,
-            direction == SOAPY_SDR_TX, datagramMode, channels.size(),
+        data.endpoint = new SoapyStreamEndpoint(*data.streamSock, *data.statusSock,
+            datagramMode, direction == SOAPY_SDR_TX, channels.size(),
             SoapySDR::formatToSize(format), mtu, window);
 
         //start worker thread, this is not backwards,
@@ -404,6 +415,9 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         if (direction == SOAPY_SDR_RX) data.startSendThread();
         if (direction == SOAPY_SDR_TX) data.startRecvThread();
         data.startStatThread();
+
+        packer & data.streamId;
+        packer & serverBindPort;
     } break;
 
     ////////////////////////////////////////////////////////////////////

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -343,8 +343,8 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
             _streamData.erase(data.streamId);
             throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- bind FAIL: " + errorMsg);
         }
-        SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", data.streamSock.getsockname().c_str());
-        const auto serverBindPort = SoapyURL(data.streamSock.getsockname()).getService();
+        SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", serverSocket.getsockname().c_str());
+        const auto serverBindPort = SoapyURL(serverSocket.getsockname()).getService();
 
         //in udp mode connect to the bound sockets on the client side
         if (datagramMode)
@@ -384,7 +384,10 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         //tcp mode: flush the packer and accept the client's new connections
         if (not datagramMode)
         {
-            packer();
+            SoapyRPCPacker packer2(_sock);
+            packer2 & data.streamId;
+            packer2 & serverBindPort;
+            packer2();
             //TODO fix leak
             data.streamSock = *serverSocket.accept();
             data.statusSock = *serverSocket.accept();

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -311,6 +311,11 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         const auto priorityIt = args.find(SOAPY_REMOTE_KWARG_PRIORITY);
         if (priorityIt != args.end()) priority = std::stod(priorityIt->second);
 
+        std::string prot = "udp";
+        const auto protIt = args.find(SOAPY_REMOTE_KWARG_PROT);
+        if (protIt != args.end()) prot = protIt->second;
+        const bool datagramMode = (prot == "udp");
+
         //create stream
         auto stream = _dev->setupStream(direction, format, channels, args);
 
@@ -328,42 +333,67 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         const auto remoteNode = SoapyURL(_sock.getpeername()).getNode();
 
         //bind the stream socket to an automatic port
-        const auto bindURL = SoapyURL("udp", localNode, "0").toString();
-        int ret = data.streamSock.bind(bindURL);
+        const auto bindURL = SoapyURL(prot, localNode, "0").toString();
+        SoapyRPCSocket tcpServerSocket;
+        auto &serverSocket = datagramMode?data.streamSock:tcpServerSocket;
+        int ret = serverSocket.bind(bindURL);
         if (ret != 0)
         {
-            const std::string errorMsg = data.streamSock.lastErrorMsg();
+            const std::string errorMsg = serverSocket.lastErrorMsg();
             _streamData.erase(data.streamId);
             throw std::runtime_error("SoapyRemote::setupStream("+bindURL+") -- bind FAIL: " + errorMsg);
         }
         SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", data.streamSock.getsockname().c_str());
         const auto serverBindPort = SoapyURL(data.streamSock.getsockname()).getService();
 
-        //connect the stream socket to the specified port
-        auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
-        ret = data.streamSock.connect(connectURL);
-        if (ret != 0)
+        //in udp mode connect to the bound sockets on the client side
+        if (datagramMode)
         {
-            const std::string errorMsg = data.streamSock.lastErrorMsg();
-            _streamData.erase(data.streamId);
-            throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
-        }
-        SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock.getpeername().c_str());
+            //connect the stream socket to the specified port
+            auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
+            ret = data.streamSock.connect(connectURL);
+            if (ret != 0)
+            {
+                const std::string errorMsg = data.streamSock.lastErrorMsg();
+                _streamData.erase(data.streamId);
+                throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
+            }
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock.getpeername().c_str());
 
-        //connect the status socket to the specified port
-        connectURL = SoapyURL("udp", remoteNode, statusBindPort).toString();
-        ret = data.statusSock.connect(connectURL);
-        if (ret != 0)
-        {
-            const std::string errorMsg = data.statusSock.lastErrorMsg();
-            _streamData.erase(data.streamId);
-            throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
+            //connect the status socket to the specified port
+            connectURL = SoapyURL("udp", remoteNode, statusBindPort).toString();
+            ret = data.statusSock.connect(connectURL);
+            if (ret != 0)
+            {
+                const std::string errorMsg = data.statusSock.lastErrorMsg();
+                _streamData.erase(data.streamId);
+                throw std::runtime_error("SoapyRemote::setupStream("+connectURL+") -- connect FAIL: " + errorMsg);
+            }
+            SoapySDR::logf(SOAPY_SDR_INFO, "Server side status connected to %s", data.statusSock.getpeername().c_str());
         }
-        SoapySDR::logf(SOAPY_SDR_INFO, "Server side status connected to %s", data.statusSock.getpeername().c_str());
+
+        //in tcp mode, setup the server socket to listen
+        else
+        {
+            serverSocket.listen(2);
+        }
+
+        packer & data.streamId;
+        packer & serverBindPort;
+
+        //tcp mode: flush the packer and accept the client's new connections
+        if (not datagramMode)
+        {
+            packer();
+            //TODO fix leak
+            data.streamSock = *serverSocket.accept();
+            data.statusSock = *serverSocket.accept();
+        }
 
         //create endpoint
         data.endpoint = new SoapyStreamEndpoint(data.streamSock, data.statusSock,
-            direction == SOAPY_SDR_TX, true, channels.size(), SoapySDR::formatToSize(format), mtu, window);
+            direction == SOAPY_SDR_TX, datagramMode, channels.size(),
+            SoapySDR::formatToSize(format), mtu, window);
 
         //start worker thread, this is not backwards,
         //receive from device means using a send endpoint
@@ -371,9 +401,6 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         if (direction == SOAPY_SDR_RX) data.startSendThread();
         if (direction == SOAPY_SDR_TX) data.startRecvThread();
         data.startStatThread();
-
-        packer & data.streamId;
-        packer & serverBindPort;
     } break;
 
     ////////////////////////////////////////////////////////////////////

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -328,6 +328,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         const auto remoteNode = SoapyURL(_sock.getpeername()).getNode();
 
         //bind the stream socket to an automatic port
+        /*
         const auto bindURL = SoapyURL("udp", localNode, "0").toString();
         int ret = data.streamSock.bind(bindURL);
         if (ret != 0)
@@ -338,10 +339,11 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         }
         SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream bound to %s", data.streamSock.getsockname().c_str());
         const auto serverBindPort = SoapyURL(data.streamSock.getsockname()).getService();
+        */
 
         //connect the stream socket to the specified port
-        auto connectURL = SoapyURL("udp", remoteNode, clientBindPort).toString();
-        ret = data.streamSock.connect(connectURL);
+        auto connectURL = SoapyURL("tcp", remoteNode, clientBindPort).toString();
+        int ret = data.streamSock.connect(connectURL);
         if (ret != 0)
         {
             const std::string errorMsg = data.streamSock.lastErrorMsg();
@@ -351,7 +353,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         SoapySDR::logf(SOAPY_SDR_INFO, "Server side stream connected to %s", data.streamSock.getpeername().c_str());
 
         //connect the status socket to the specified port
-        connectURL = SoapyURL("udp", remoteNode, statusBindPort).toString();
+        connectURL = SoapyURL("tcp", remoteNode, statusBindPort).toString();
         ret = data.statusSock.connect(connectURL);
         if (ret != 0)
         {
@@ -373,7 +375,7 @@ bool SoapyClientHandler::handleOnce(SoapyRPCUnpacker &unpacker, SoapyRPCPacker &
         data.startStatThread();
 
         packer & data.streamId;
-        packer & serverBindPort;
+        packer & std::string("");//serverBindPort;
     } break;
 
     ////////////////////////////////////////////////////////////////////

--- a/server/ServerStreamData.cpp
+++ b/server/ServerStreamData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2015 Josh Blum
+// Copyright (c) 2015-2016 Josh Blum
 // Copyright (c) 2016-2016 Bastille Networks
 // SPDX-License-Identifier: BSL-1.0
 
@@ -27,12 +27,20 @@ ServerStreamData::ServerStreamData(void):
     chanMask(0),
     priority(0.0),
     streamId(-1),
+    streamSock(nullptr),
+    statusSock(nullptr),
     endpoint(nullptr),
     streamThread(nullptr),
     statusThread(nullptr),
     done(true)
 {
     return;
+}
+
+ServerStreamData::~ServerStreamData(void)
+{
+    delete streamSock;
+    delete statusSock;
 }
 
 void ServerStreamData::startSendThread(void)
@@ -100,7 +108,7 @@ void ServerStreamData::recvEndpointWork(void)
         ret = endpoint->acquireRecv(handle, buffs.data(), flags, timeNs);
         if (ret < 0)
         {
-            SoapySDR::logf(SOAPY_SDR_ERROR, "Server-side receive endpoint: %s; worker quitting...", streamSock.lastErrorMsg());
+            SoapySDR::logf(SOAPY_SDR_ERROR, "Server-side receive endpoint: %s; worker quitting...", streamSock->lastErrorMsg());
             return;
         }
 
@@ -153,7 +161,7 @@ void ServerStreamData::sendEndpointWork(void)
         ret = endpoint->acquireSend(handle, buffs.data());
         if (ret < 0)
         {
-            SoapySDR::logf(SOAPY_SDR_ERROR, "Server-side send endpoint: %s; worker quitting...", streamSock.lastErrorMsg());
+            SoapySDR::logf(SOAPY_SDR_ERROR, "Server-side send endpoint: %s; worker quitting...", streamSock->lastErrorMsg());
             return;
         }
 

--- a/server/ServerStreamData.hpp
+++ b/server/ServerStreamData.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2015 Josh Blum
+// Copyright (c) 2015-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -25,6 +25,7 @@ class ServerStreamData
 {
 public:
     ServerStreamData(void);
+    ~ServerStreamData(void);
 
     SoapySDR::Device *device;
     SoapySDR::Stream *stream;
@@ -36,10 +37,10 @@ public:
     int streamId;
 
     //datagram socket for stream endpoint
-    SoapyRPCSocket streamSock;
+    SoapyRPCSocket *streamSock;
 
     //datagram socket for status endpoint
-    SoapyRPCSocket statusSock;
+    SoapyRPCSocket *statusSock;
 
     //remote side of the stream endpoint
     SoapyStreamEndpoint *endpoint;


### PR DESCRIPTION
When remote:prot is specified for the device or stream args, tcp will be used making stream transfer sizes and streams reliable. TCP offers a reliability tradeoff for a loss in performance. Some applications cannot tolerate the dropping that may occur when using UDP.
