### PR TITLE
Fix TX bug when driver reports too much elems written

### DIFF
--- a/server/ServerStreamData.cpp
+++ b/server/ServerStreamData.cpp
@@ -127,6 +127,11 @@ void ServerStreamData::recvEndpointWork(void)
                 endpoint->writeStatus(ret, chanMask, flags, timeNs);
                 break; //discard after error, this may have been invalid flags or time
             }
+            if (elemsLeft < (size_t)ret)
+            {
+                SoapySDR_logf(SOAPY_SDR_ERROR, "Server-side receive endpoint: device->writeStream wrote more elements than requested");
+                break; //stop after error
+            }
             elemsLeft -= ret;
             incrementBuffs(buffs, ret, elemSize);
             if (elemsLeft == 0) break;


### PR DESCRIPTION
A server-side driver may report more bytes written than requested on ret=writeStream(). Then elemsLeft -= ret will wrap around (size_t, i.e. unsigned). This will lead to an endless loop and trigger OOB access.
This modification checks that elemsLeft can safely be reduced by ret, otherwise set it to 0.