### PR TITLE
compiler checks for strerror_r variants

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,7 +2,7 @@ Release 0.5.1 (pending)
 ==========================
 
 - Added explicit compile flags for MSVC needed by common
-- Compilation fixes for FreeBSD
+- Compilation fixes for strerror_r API differences
 
 Release 0.5.0 (2018-10-24)
 ==========================

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -41,6 +41,13 @@ CHECK_INCLUDE_FILES(ifaddrs.h HAS_IFADDRS_H)
 CHECK_INCLUDE_FILES(net/if.h HAS_NET_IF_H)
 CHECK_INCLUDE_FILES(fcntl.h HAS_FCNTL_H)
 
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("#include <cstring>
+int main(void){return strerror_r(0, NULL, 0);}" STRERROR_R_XSI)
+if (STRERROR_R_XSI)
+    add_definitions(-DSTRERROR_R_XSI)
+endif ()
+
 #network libraries
 if (WIN32)
     list(APPEND SoapySDR_LIBRARIES ws2_32)

--- a/common/SoapyRPCSocket.cpp
+++ b/common/SoapyRPCSocket.cpp
@@ -496,7 +496,7 @@ static std::string errToString(const int err)
     return buff;
     #else
     //http://linux.die.net/man/3/strerror_r
-    #if ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE) || __APPLE__ || __FreeBSD__
+    #ifdef STRERROR_R_XSI
     strerror_r(err, buff, sizeof(buff));
     #else
     //this version may decide to use its own internal string


### PR DESCRIPTION
Its hard to get ifdefs correct for strerror_r, this adds a compiler check for the variant so it should be correct every time.

* Resolves https://github.com/pothosware/SoapyRemote/issues/57