### PR TITLE
MDNS timeout for OSX when no servers are available

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,7 @@
 Release 0.5.1 (pending)
 ==========================
 
+- MDNS timeout for OSX when no servers are available
 - Added explicit compile flags for MSVC needed by common
 - Compilation fixes for strerror_r API differences
 


### PR DESCRIPTION
fixes a possible lockup condition when discovering servers
DNSServiceProcessResult can block forever in this case

* resolves https://github.com/pothosware/SoapyRemote/issues/61