### PR TITLE
Fix the scale in CS12 - CF32 conversion

### DIFF
--- a/client/ClientStreamData.cpp
+++ b/client/ClientStreamData.cpp
@@ -60,7 +60,8 @@ void ClientStreamData::convertRecvBuffs(void * const *buffs, const size_t numEle
     case CONVERT_CF32_CS12:
     ///////////////////////////
     {
-        const float scale = float(1.0/scaleFactor);
+        // note that we correct the scale for the CS16 intermediate step
+        const float scale = float(1.0/16.0/scaleFactor);
         for (size_t i = 0; i < recvBuffs.size(); i++)
         {
             auto in = (uint8_t *)recvBuffs[i];
@@ -193,7 +194,8 @@ void ClientStreamData::convertSendBuffs(const void * const *buffs, const size_t 
     case CONVERT_CF32_CS12:
     ///////////////////////////
     {
-        const float scale = float(scaleFactor);
+        // note that we correct the scale for the CS16 intermediate step
+        const float scale = float(16.0*scaleFactor);
         for (size_t i = 0; i < sendBuffs.size(); i++)
         {
             auto in = (float *)buffs[i];


### PR DESCRIPTION
CS12 will have a full scale of 2048 or less. The intermediate step to CS16 raises the scale by 16 to e.g. 32768. The float scaling is corrected for this.

We keep the MSB alignment from CS12 to CS16 otherwise a sign-extend would be needed. Hence we can't keep the existing CS12 scale for CS16, and need the float scale correction by 16.0 (4 bits)

S.a. https://github.com/pothosware/SoapyPlutoSDR/pull/19