### PR TITLE
Fix wrong remote:scale argument parsing

### DIFF
--- a/client/Streaming.cpp
+++ b/client/Streaming.cpp
@@ -188,7 +188,7 @@ SoapySDR::Stream *SoapyRemoteDevice::setupStream(
     //use the native scale factor when the remote format is native,
     //otherwise the default scale factor is the max signed integer
     double scaleFactor = (remoteFormat == nativeFormat)?nativeScaleFactor:double(1 << ((SoapySDR::formatToSize(remoteFormat)*4)-1));
-    const auto scaleFactorIt = args.find(SOAPY_REMOTE_KWARG_SCALAR);
+    const auto scaleFactorIt = args.find(SOAPY_REMOTE_KWARG_SCALE);
     if (scaleFactorIt != args.end()) scaleFactor = std::stod(scaleFactorIt->second);
 
     //determine reliable stream mode with tcp or datagram mode

--- a/common/SoapyRemoteDefs.hpp
+++ b/common/SoapyRemoteDefs.hpp
@@ -17,8 +17,8 @@
 //! Stream args key to set the format on the remote server
 #define SOAPY_REMOTE_KWARG_FORMAT (SOAPY_REMOTE_KWARG_PREFIX "format")
 
-//! Stream args key to set the scalar for local float conversions
-#define SOAPY_REMOTE_KWARG_SCALAR (SOAPY_REMOTE_KWARG_PREFIX "scalar")
+//! Stream args key to set the scale for local float conversions
+#define SOAPY_REMOTE_KWARG_SCALE (SOAPY_REMOTE_KWARG_PREFIX "scale")
 
 //! Stream args key to set the buffer MTU bytes for network transfers
 #define SOAPY_REMOTE_KWARG_MTU (SOAPY_REMOTE_KWARG_PREFIX "mtu")


### PR DESCRIPTION
Fix the `remote:scale` argument processing, removed the erroneous definition of `scalar` in SoapyRemote defs. Fix problem seen in Cubic while testing https://github.com/pothosware/SoapyPlutoSDR/pull/19.

Now that #65 is in master, selecting the `CS12` with scale 2048 shows the right scale for local `CF32`.