### PR TITLE
update to modern cmake conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 ########################################################################
 # Build Soapy SDR remote support
 ########################################################################
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.1.0)
 project(SoapyRemote CXX C)
+
+#C++11 is a required language feature for this project
+set(CMAKE_CXX_STANDARD 11)
 
 #extract changelog version
 file(READ "${PROJECT_SOURCE_DIR}/Changelog.txt" changelog_txt)
@@ -32,37 +35,8 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
-#find soapy sdr
-find_package(SoapySDR "0.4.0" NO_MODULE)
-
-#enable c++11 features
-if(CMAKE_COMPILER_IS_GNUCXX)
-
-    #C++11 is a required language feature for this project
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_STD_CXX11)
-    if(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    else(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    endif()
-
-    #Thread support enabled (not the same as -lpthread)
-    list(APPEND SoapySDR_LIBRARIES -pthread)
-
-endif(CMAKE_COMPILER_IS_GNUCXX)
-
-#link threads in freebsd
-if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-    find_package(Threads)
-    message(STATUS "CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
-    list(APPEND SoapySDR_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-endif()
-
-#enable c++11 extensions for OSX
-if (APPLE)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wc++11-extensions")
-endif(APPLE)
+#find soapy sdr with modern cmake support
+find_package(SoapySDR "0.8.0" CONFIG)
 
 if(MSVC)
     #we always want to use multiple cores for compilation
@@ -71,9 +45,6 @@ if(MSVC)
     #projects should be cross-platform and standard stl functions should work
     add_definitions(-DNOMINMAX) #enables std::min and std::max
 endif()
-
-#common headers used by client and server
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)
 
 add_subdirectory(common)
 add_subdirectory(client)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,7 +1,9 @@
 ########################################################################
 # Build the remote support library
 ########################################################################
-set(COMMON_SOURCES
+
+#build a static library
+add_library(SoapySDRRemoteCommon STATIC
     SoapyURLUtils.cpp
     SoapyRPCSocket.cpp
     SoapyRPCPacker.cpp
@@ -9,14 +11,17 @@ set(COMMON_SOURCES
     SoapyStreamEndpoint.cpp
     SoapyHTTPUtils.cpp
     SoapySSDPEndpoint.cpp
-    SoapyIfAddrs.cpp
-)
+    SoapyIfAddrs.cpp)
+
+target_include_directories(SoapySDRRemoteCommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(SoapySDRRemoteCommon PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 #network interface enumeration
 if (WIN32)
-    list(APPEND COMMON_SOURCES SoapyIfAddrsWindows.cpp)
+    target_sources(SoapySDRRemoteCommon PRIVATE SoapyIfAddrsWindows.cpp)
 else ()
-    list(APPEND COMMON_SOURCES SoapyIfAddrsUnix.cpp)
+    target_sources(SoapySDRRemoteCommon PRIVATE SoapyIfAddrsUnix.cpp)
 endif ()
 
 #configure ssdp defines
@@ -24,7 +29,7 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/SoapyInfoUtils.in.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/SoapyInfoUtils.cpp
 @ONLY)
-list(APPEND COMMON_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/SoapyInfoUtils.cpp)
+target_sources(SoapySDRRemoteCommon PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/SoapyInfoUtils.cpp)
 
 #check for platform-specific network header
 include(CheckIncludeFiles)
@@ -45,12 +50,12 @@ include(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("#include <cstring>
 int main(void){return strerror_r(0, NULL, 0);}" STRERROR_R_XSI)
 if (STRERROR_R_XSI)
-    add_definitions(-DSTRERROR_R_XSI)
+    target_compile_definitions(SoapySDRRemoteCommon PRIVATE -DSTRERROR_R_XSI)
 endif ()
 
 #network libraries
 if (WIN32)
-    list(APPEND SoapySDR_LIBRARIES ws2_32)
+    target_link_libraries(SoapySDRRemoteCommon PRIVATE ws2_32)
 endif (WIN32)
 
 #avahi for discovery over mDNS/DNS-SD daemon
@@ -66,25 +71,26 @@ if (UNIX AND NOT APPLE)
 endif ()
 
 if (APPLE)
-    list(APPEND COMMON_SOURCES SoapyMDNSEndpointApple.cpp)
+    target_sources(SoapySDRRemoteCommon PRIVATE SoapyMDNSEndpointApple.cpp)
 elseif (AVAHI_FOUND)
     message(STATUS "AVAHI_INCLUDE_DIRS=${AVAHI_INCLUDE_DIRS}")
     message(STATUS "AVAHI_LIBRARIES=${AVAHI_LIBRARIES}")
-    include_directories(${AVAHI_INCLUDE_DIRS})
-    list(APPEND SoapySDR_LIBRARIES ${AVAHI_LIBRARIES})
-    list(APPEND COMMON_SOURCES SoapyMDNSEndpointAvahi.cpp)
+    target_include_directories(SoapySDRRemoteCommon PRIVATE ${AVAHI_INCLUDE_DIRS})
+    target_link_libraries(SoapySDRRemoteCommon PRIVATE ${AVAHI_LIBRARIES})
+    target_sources(SoapySDRRemoteCommon PRIVATE SoapyMDNSEndpointAvahi.cpp)
 else ()
-    list(APPEND COMMON_SOURCES SoapyMDNSEndpointNone.cpp)
+    target_sources(SoapySDRRemoteCommon PRIVATE SoapyMDNSEndpointNone.cpp)
 endif ()
 
 #create private include header for network compatibility
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(SoapySDRRemoteCommon PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/SoapySocketDefs.in.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/SoapySocketDefs.hpp)
 
-#build a static library
-include_directories(${SoapySDR_INCLUDE_DIRS})
-add_library(SoapySDRRemoteCommon STATIC ${COMMON_SOURCES})
-target_link_libraries(SoapySDRRemoteCommon ${SoapySDR_LIBRARIES})
-set_property(TARGET SoapySDRRemoteCommon PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+#link threads library
+find_package(Threads)
+message(STATUS "CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
+if (CMAKE_THREAD_LIBS_INIT)
+    target_link_libraries(SoapySDRRemoteCommon PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,4 +1,26 @@
 ########################################################################
+# Build the remote server application
+########################################################################
+add_executable(SoapySDRServer
+    SoapyServer.cpp
+    ServerListener.cpp
+    ClientHandler.cpp
+    LogForwarding.cpp
+    ServerStreamData.cpp)
+
+target_link_libraries(SoapySDRServer PRIVATE SoapySDR SoapySDRRemoteCommon)
+
+target_include_directories(SoapySDRServer PRIVATE ${SOAPY_SERVER_SOURCES})
+if (MSVC)
+    target_include_directories(SoapySDRServer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/msvc)
+endif ()
+
+install(TARGETS SoapySDRServer DESTINATION bin)
+
+#install man pages for the application executable
+install(FILES SoapySDRServer.1 DESTINATION share/man/man1)
+
+########################################################################
 # Thread config support
 ########################################################################
 find_library(
@@ -8,32 +30,11 @@ find_library(
 )
 
 if (RT_LIBRARIES)
-    list(APPEND SoapySDR_LIBRARIES ${RT_LIBRARIES})
+    target_link_libraries(SoapySDRServer PRIVATE ${RT_LIBRARIES})
 endif()
 
 if(WIN32)
-    list(APPEND SOAPY_SERVER_SOURCES ThreadPrioWindows.cpp)
+    target_sources(SoapySDRServer PRIVATE ThreadPrioWindows.cpp)
 elseif(UNIX)
-    list(APPEND SOAPY_SERVER_SOURCES ThreadPrioUnix.cpp)
+    target_sources(SoapySDRServer PRIVATE ThreadPrioUnix.cpp)
 endif()
-
-########################################################################
-# Build the remote server application
-########################################################################
-list(APPEND SOAPY_SERVER_SOURCES
-    SoapyServer.cpp
-    ServerListener.cpp
-    ClientHandler.cpp
-    LogForwarding.cpp
-    ServerStreamData.cpp
-)
-if (MSVC)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/msvc)
-endif ()
-include_directories(${SoapySDR_INCLUDE_DIRS})
-add_executable(SoapySDRServer ${SOAPY_SERVER_SOURCES})
-target_link_libraries(SoapySDRServer ${SoapySDR_LIBRARIES} SoapySDRRemoteCommon)
-install(TARGETS SoapySDRServer DESTINATION bin)
-
-#install man pages for the application executable
-install(FILES SoapySDRServer.1 DESTINATION share/man/man1)


### PR DESCRIPTION
* Making a pull request to see if it passes CI
* Modern use of CI to cleanup cmake use
* Bumps use of cmake to v3.0 and SoapySDR 0.8 (use maint for soapysdr release)
* resolves https://github.com/pothosware/SoapyRemote/issues/68