### PR TITLE
Fix install path for systemd file

### DIFF
--- a/system/CMakeLists.txt
+++ b/system/CMakeLists.txt
@@ -5,7 +5,7 @@ option(ENABLE_SYSTEMD "Install systemd unit" ON)
 if(ENABLE_SYSTEMD)
 
     if("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
-        set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system)
+        set(SYSTEMD_UNIT_INSTALL_DIR /usr/lib/systemd/system)
     else()
         #source installs will use the install prefix
         set(SYSTEMD_UNIT_INSTALL_DIR lib/systemd/system)


### PR DESCRIPTION
According to the Filesystem Hierarchy Standard (see [1]) /lib is reserved
for "essential shared libraries and kernel modules", which doesn't
include systemd unit files.

Instead our SoapySDRServer systemd unit should rather be installed
at /usr/lib/..., respecting the install prefix set by
"CMAKE_INSTALL_PREFIX=/usr".

Fixes installation issues on Archlinux (see [2]).

[1]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.pdf
[2]: https://aur.archlinux.org/packages/soapyremote-git/#comment-713651

Signed-off-by: Fabian P. Schmidt <kerel@mailbox.org>