### PR TITLE
use gnu install dirs for cmake install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
+# Use standard GNU install paths
+include(GNUInstallDirs)
+
 #find soapy sdr with modern cmake support
 find_package(SoapySDR "0.8.0" CONFIG)
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -15,10 +15,10 @@ if (MSVC)
     target_include_directories(SoapySDRServer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/msvc)
 endif ()
 
-install(TARGETS SoapySDRServer DESTINATION bin)
+install(TARGETS SoapySDRServer DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 #install man pages for the application executable
-install(FILES SoapySDRServer.1 DESTINATION share/man/man1)
+install(FILES SoapySDRServer.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 ########################################################################
 # Thread config support

--- a/system/CMakeLists.txt
+++ b/system/CMakeLists.txt
@@ -4,14 +4,7 @@
 option(ENABLE_SYSTEMD "Install systemd unit" ON)
 if(ENABLE_SYSTEMD)
 
-    if("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
-        set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system)
-    else()
-        #source installs will use the install prefix
-        set(SYSTEMD_UNIT_INSTALL_DIR lib/systemd/system)
-    endif()
-
-    set(SYSTEMD_UNIT_DIR "${SYSTEMD_UNIT_INSTALL_DIR}" CACHE STRING "Directory to install systemd unit")
+    set(SYSTEMD_UNIT_DIR "lib/systemd/system" CACHE STRING "Directory to install systemd unit")
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/SoapySDRServer.service.in
@@ -20,7 +13,7 @@ if(ENABLE_SYSTEMD)
 
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SoapySDRServer.service
-        DESTINATION ${SYSTEMD_UNIT_DIR})
+        DESTINATION "${SYSTEMD_UNIT_DIR}")
 endif()
 
 ########################################################################
@@ -28,8 +21,11 @@ endif()
 ########################################################################
 option(ENABLE_SYSCTL "Install kernel tweaks for socket buffer sizes" ON)
 if(ENABLE_SYSCTL)
+
+    set(SYSCTL_CONFIG_DIR "lib/sysctl.d" CACHE STRING "Directory to install sysctl.d configs")
+
     install(
         FILES SoapySDRServer.sysctl
         RENAME 10-SoapySDRServer.conf
-        DESTINATION lib/sysctl.d)
+        DESTINATION "${SYSCTL_CONFIG_DIR}")
 endif()

--- a/system/SoapySDRServer.service.in
+++ b/system/SoapySDRServer.service.in
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=@CMAKE_INSTALL_PREFIX@/bin/SoapySDRServer --bind
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/SoapySDRServer --bind
 KillMode=process
 Restart=on-failure
 LimitRTPRIO=99


### PR DESCRIPTION
* use gnu install dirs for cmake install rules
* added variable to configure sysctl directory
* simplify systemd unit directory and default
* closes https://github.com/pothosware/SoapyRemote/pull/83