### PR TITLE
Fix scaling in CS16-CS8 conversion

### DIFF
--- a/client/ClientStreamData.cpp
+++ b/client/ClientStreamData.cpp
@@ -104,13 +104,15 @@ void ClientStreamData::convertRecvBuffs(void * const *buffs, const size_t numEle
     case CONVERT_CS16_CS8:
     ///////////////////////////
     {
+        // note that we expect CS8 scaleFactor to be power of 2, usually 128
+        const int scale = 32768/int(scaleFactor);
         for (size_t i = 0; i < recvBuffs.size(); i++)
         {
             auto in = (int8_t *)recvBuffs[i];
             auto out = (int16_t *)buffs[i];
             for (size_t j = 0; j < numElems*2; j++)
             {
-                out[j] = int16_t(in[j]);
+                out[j] = int16_t(in[j])*scale;
             }
         }
     }
@@ -236,13 +238,15 @@ void ClientStreamData::convertSendBuffs(const void * const *buffs, const size_t 
     case CONVERT_CS16_CS8:
     ///////////////////////////
     {
+        // note that we expect CS16 scaleFactor to be a power of 2, usually 2048
+        const int scale = int(scaleFactor + 1)/128; // round e.g. 2047.0 and 32767.0
         for (size_t i = 0; i < sendBuffs.size(); i++)
         {
             auto in = (int16_t *)buffs[i];
             auto out = (int8_t *)sendBuffs[i];
             for (size_t j = 0; j < numElems*2; j++)
             {
-                out[j] = int8_t(in[j]);
+                out[j] = int8_t(in[j]/scale);
             }
         }
     }


### PR DESCRIPTION
Currently the CS16-CS8 conversion applies no scaling.

This works somewhat for "remoteFormat=CS8, localFormat=CS16" but since CS16 then isn't native there is no scaling info (just scale=128 for CS8) and a full-scale of 32768 is expected (rescaled by 256).

The other way around is somewhat worse, CS16 usually has a scale of 2048 or 32768 and going to CS8 without scaling clips the upper bits. It might work if the CS16 is a full-scale of 2048 and somewhat quiet. Also this might be pretty invisible as it's not a common use-case.

This change expects CS8 scaleFactor to be power of 2, usually 128 and uses an integer multiplication for fast and precise scaling.
CS8 with a full-scale other than 128 is unexpected but the scaling will still work, with some minor rounding error perhaps.

The CS16 to CS8 scales with a fast integer division as more precission won't reflect in the resulting CS8.
Rounding of the CS16 full-scale will work well with e.g. 2047.0 - 2048.0 or 32767.0 - 32768.0 to get a power of 2 as divisor.

Caveat: the CS8 to CS16 fix will affect consumers that (wrongly) assume that the native (remote) full-scale info applies to the localFormat -- but I don't known about any consumer with a hack like that?
Also the CS16 to CS8 fix might lose information if the CS16 is not data according to the declared full-scale. Again that is broken behaviour and unlikely to exist.